### PR TITLE
Proposal to use upstream image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM danger89/cmake:latest
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
- && apt-get install -y vim googletest gcovr \
+ && apt-get install -y --no-install-recommends vim googletest gcovr \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM danger89/cmake:latest
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update 
+RUN apt-get update \
  && apt-get install -y vim googletest gcovr \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,8 @@
-FROM debian:buster-slim
-LABEL maintainer="micha.hoiting@gmail.com"
+FROM danger89/cmake:latest
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get --allow-releaseinfo-change update
-RUN apt-get install -y build-essential cmake libboost-all-dev pkg-config                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
-RUN apt-get install -y ninja-build doxygen graphviz
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    locales \
-    python3-pip \
-    ca-certificates \
-    vim \
-    curl \
-    netbase \
-    wget \
-    gnupg \
-    dirmngr \
-    bzr \
-    git \
-    openssh-client \
-    procps \
-    rpm \
-    sshpass \
-    cppcheck \
-    valgrind \
-    gdb \
-    googletest \
-    gcovr \
+RUN apt-get update 
+ && apt-get install -y vim googletest gcovr \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN pip3 install cpplint
-
-# set the locale to en_US.UTF-8
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    dpkg-reconfigure locales && \
-    update-locale LANG=en_US.UTF-8
-ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
To avoid *out-of-sync* issues from [upstream](https://github.com/danger89/cmake-docker/commits/master), I advice to use the Docker way of working.

Which can be achieved via `FROM <docker_image>:<tag>`, to create a depend on another docker image (which is `danger89/cmake` in this case). In this case latest, but you can also try tag: `3.0`, better safe than sorry right?